### PR TITLE
Closes #14 - Add checks and error messages during install

### DIFF
--- a/_static/_stay/index.html
+++ b/_static/_stay/index.html
@@ -1,3 +1,41 @@
-curl -s -L https://raw.githubusercontent.com/azohra/strapped.sh/0.1.2/strapped --output /usr/local/bin/strapped
-chmod u+x /usr/local/bin/strapped
-echo "🔫 #StayStrapped"
+print_folder_err() {
+  echo "Could not install strapped to /usr/local/bin" > /dev/stderr
+  echo "" > /dev/stderr
+  echo "\tPlease try again after creating the directory:" > /dev/stderr
+  echo "\t\t$ sudo mkdir /usr/local/bin" > /dev/stderr
+  echo "\t\t$ sudo chmod u+w /usr/local/bin" > /dev/stderr
+  echo "" > /dev/stderr
+  exit 1
+}
+
+print_copy_err() {
+  echo "Could not copy strapped to your system!" > /dev/stderr
+  echo "" > /dev/stderr
+  echo "\tPlease grant permission to copy strapped:" > /dev/stderr
+  echo "\t\t$ sudo chmod u+w /usr/local/bin" > /dev/stderr
+  echo "" > /dev/stderr
+}
+
+print_chmod_err() {
+  echo "Strapped has been succesfully installed, but it needs further permissions to run!" > /dev/stderr
+  echo "" > /dev/stderr
+  echo "\tExecute the following command before running strapped" > /dev/stderr
+  echo "\t\t$ sudo chmod u+x /usr/local/bin/strapped" > /dev/stderr
+  echo "" > /dev/stderr
+}
+
+print_path_err() {
+  echo "Your system path does not currently contain /usr/local/bin" > /dev/stderr
+  echo "" > /dev/stderr
+  echo "\tYou will need to execute (and add to your .bashrc) this command" > /dev/stderr
+  echo "\t\t$ export PATH=$PATH:/usr/local/bin" > /dev/stderr
+  echo "" > /dev/stderr
+}
+
+if [ ! -d '/usr/local/bin' ]; then
+  mkdir /usr/local/bin 2> /dev/null || print_folder_err
+fi
+curl -s -L https://raw.githubusercontent.com/azohra/strapped.sh/0.1.2/strapped --output /usr/local/bin/strapped || print_copy_err
+echo "Your all set to 🔫 #StayStrapped"
+chmod u+x /usr/local/bin/strapped 2> /dev/null || print_chmod_err
+echo $PATH | grep "[:^]/usr/local/bin[:$]" || print_path_err()


### PR DESCRIPTION
Added in error messages during install steps for edge cases that systems could have if not set up the way we expect.

Also, we should test this on an actual fresh computer. I have been testing on a Docker image that I built to simulate as close as possible to a fresh computer but I may have missed some things.

Closes #14 