### PR TITLE
Added asdf strap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 INSTALL_DIR=/usr/local/bin
 
+# List of files that contain the version
+VERSIONED_FILES=strapped src/helpers.sh _static/_stay/index.html
+VERSION="0.3.0"
+
+VERSION_REPLACE_EXP="s/^VERSION=\".+\"/VERSION=\"${VERSION}\"/g"
+
 .PHONY: all exec install uninstall test strap straps docs
 
 all: exec straps binary docs test   
@@ -15,13 +21,13 @@ test:
 docs:
 	@./build/docs.sh
 
-strap:
+strap: update-version
 	@./build/compiler.sh ${yml}
 
-straps:
+straps: update-version
 	@./build/straps.sh
 
-binary:
+binary: update-version
 	@./build/binary.sh
 
 install: strapped
@@ -33,3 +39,10 @@ install: strapped
 uninstall:
 	@echo "🗑️  Uninstalling strapped"
 	@rm $(INSTALL_DIR)/strapped
+
+$(VERSIONED_FILES): Makefile
+	@echo "Updateing version in " $@ " to "$(VERSION)
+	@sed -i .old -E $(VERSION_REPLACE_EXP) $@ && rm "$@.old"
+
+.PHONY: update-version
+update-version: $(VERSIONED_FILES)

--- a/_static/_stay/index.html
+++ b/_static/_stay/index.html
@@ -1,3 +1,4 @@
+VERSION="0.3.0"
 print_folder_err() {
   echo "Could not install strapped to /usr/local/bin" > /dev/stderr
   echo "" > /dev/stderr
@@ -35,7 +36,7 @@ print_path_err() {
 if [ ! -d '/usr/local/bin' ]; then
   mkdir /usr/local/bin 2> /dev/null || print_folder_err
 fi
-curl -s -L https://raw.githubusercontent.com/azohra/strapped.sh/0.2.0/strapped --output /usr/local/bin/strapped || print_copy_err
+curl -s -L "https://raw.githubusercontent.com/azohra/strapped.sh/$VERSION/strapped" --output /usr/local/bin/strapped || print_copy_err
 echo "Your all set to 🔫 #StayStrapped"
 chmod u+x /usr/local/bin/strapped 2> /dev/null || print_chmod_err
 echo $PATH | grep "[:^]/usr/local/bin[:$]" > /dev/null || print_path_err

--- a/src/cli.sh
+++ b/src/cli.sh
@@ -47,7 +47,7 @@ while [ $# -gt 0 ] ; do
         auto_approve="true"
     ;;
     -v|--version)
-        echo 'v0.2.0' && exit 0
+        echo "v$VERSION" && exit 0
     ;;
     -h|--help)
         usage

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # shellcheck source=/dev/null
 
+VERSION="0.3.0"
 C_GREEN="\\033[32m"
 C_BLUE="\\033[94m"
 C_REG="\\033[0;39m"

--- a/strapped
+++ b/strapped
@@ -1,6 +1,7 @@
 #!/bin/bash
 # shellcheck source=/dev/null
 
+VERSION="0.3.0"
 C_GREEN="\\033[32m"
 C_BLUE="\\033[94m"
 C_REG="\\033[0;39m"
@@ -152,7 +153,7 @@ while [ $# -gt 0 ] ; do
         auto_approve="true"
     ;;
     -v|--version)
-        echo 'v0.2.0' && exit 0
+        echo "v$VERSION" && exit 0
     ;;
     -h|--help)
         usage

--- a/straps/asdf/latest/README.md
+++ b/straps/asdf/latest/README.md
@@ -1,0 +1,19 @@
+# asdf :: v0.1.0
+
+| Attribute     | Value |
+|--------------:|----|
+| Namespace     | asdf |
+| Emoji         | 🐙 [plugins] ⌨ [versions]  |
+| Description   | Extendable version manager |
+| Dependencies  | asdf  |
+| Compatability | unix  |
+
+## Configuration
+
+```yml
+asdf:
+  plugins:
+    - { name: clojure, url: https://github.com/halcyon/asdf-clojure.git }
+  versions:
+    - { dir: ~/opeional_local_install, name: clojure, version: 1.9.0 }
+```

--- a/straps/asdf/latest/asdf.sh
+++ b/straps/asdf/latest/asdf.sh
@@ -1,0 +1,67 @@
+#!/bin/bash 
+
+function strapped_asdf() {
+	# Variables to hold the deps and corresponding checks
+	local __deps="asdf "
+	local __resp
+	# Performing each check for each dep
+	for dep in ${__deps}; do
+		command -v "${dep}" &> /dev/null
+		__resp=$?
+		if [[ $__resp -ne 0 ]]; then
+			echo "ERROR: dep ${dep} not found:"
+			case "${dep}" in
+			"asdf")
+				echo -e "
+	Please ensure you have asdf installed on your system 
+	To install asdf, follow the instructions at https://asdf-vm.com/#/core-manage-asdf-vm 
+"
+			;;
+			esac
+			exit 1
+		fi
+	done
+
+	# Declaring local variables for the 'plugins' routine
+	local name
+	local url
+
+	# Declaring local variables for the 'versions' routine
+	local dir
+	local name
+	local version
+	local input=${1}
+
+	# Initialize array iterator
+	local i=0
+
+	# performing functionality for routine 'plugins'
+	for ((i=0; i<$( ysh -T "${input}" -c plugins ); i++)); do
+
+		# Getting fields for routine 'plugins'
+		name=$( ysh -T "${input}" -l plugins -i ${i} -Q name )
+		url=$( ysh -T "${input}" -l plugins -i ${i} -Q url )
+
+		# Writing message for routine 'plugins'
+		pretty_print ":info:" "🐙 adding ${name} plugin to asdf"
+
+		# Executing the command(s) for routine 'plugins'
+		run_command "asdf plugin-add ${name} ${url}"
+	done
+
+
+	# performing functionality for routine 'versions'
+	for ((i=0; i<$( ysh -T "${input}" -c versions ); i++)); do
+
+		# Getting fields for routine 'versions'
+		dir=$( ysh -T "${input}" -l versions -i ${i} -Q dir )
+		name=$( ysh -T "${input}" -l versions -i ${i} -Q name )
+		version=$( ysh -T "${input}" -l versions -i ${i} -Q version )
+
+		# Writing message for routine 'versions'
+		pretty_print ":info:" "⌨ shimming ${name} to ${version}"
+
+		# Executing the command(s) for routine 'versions'
+		run_command "test '${dir}' && (cd ${dir} && asdf local ${name} ${version}) || asdf global global ${name} ${version}"
+	done
+}

--- a/straps/asdf/latest/asdf.sh.DIGEST
+++ b/straps/asdf/latest/asdf.sh.DIGEST
@@ -1,0 +1,1 @@
+076b4d730b35b2bc758b28f2457f7d1df0d1075a3b505dbb295978e34defa8e6  straps/asdf/v0.1.0/asdf.sh

--- a/straps/asdf/spec.yml
+++ b/straps/asdf/spec.yml
@@ -1,0 +1,23 @@
+strap:
+  namespace: asdf
+  version: v0.1.0
+  description: "Extendable version manager"
+  compatability: unix
+  deps:
+    - name: asdf
+      msg:
+        - "\n\tPlease ensure you have asdf installed on your system"
+        - "\tTo install asdf, follow the instructions at https://asdf-vm.com/#/core-manage-asdf-vm"
+  routines:
+    plugins:
+      exec: "asdf plugin-add ${name} ${url}"
+      message: "adding ${name} plugin to asdf"
+      emoji: 🐙
+      input:
+        - { name: clojure,     url: https://github.com/halcyon/asdf-clojure.git }
+    versions:
+      exec: "test '${dir}' && (cd ${dir} && asdf local ${name} ${version}) || asdf global global ${name} ${version}"
+      message: "shimming ${name} to ${version}"
+      emoji: ⌨
+      input:
+        - { name: clojure,     version: 1.9.0, dir: ~/opeional_local_install }

--- a/straps/asdf/v0.1.0/README.md
+++ b/straps/asdf/v0.1.0/README.md
@@ -1,0 +1,19 @@
+# asdf :: v0.1.0
+
+| Attribute     | Value |
+|--------------:|----|
+| Namespace     | asdf |
+| Emoji         | 🐙 [plugins] ⌨ [versions]  |
+| Description   | Extendable version manager |
+| Dependencies  | asdf  |
+| Compatability | unix  |
+
+## Configuration
+
+```yml
+asdf:
+  plugins:
+    - { name: clojure, url: https://github.com/halcyon/asdf-clojure.git }
+  versions:
+    - { dir: ~/opeional_local_install, name: clojure, version: 1.9.0 }
+```

--- a/straps/asdf/v0.1.0/asdf.sh
+++ b/straps/asdf/v0.1.0/asdf.sh
@@ -1,0 +1,67 @@
+#!/bin/bash 
+
+function strapped_asdf() {
+	# Variables to hold the deps and corresponding checks
+	local __deps="asdf "
+	local __resp
+	# Performing each check for each dep
+	for dep in ${__deps}; do
+		command -v "${dep}" &> /dev/null
+		__resp=$?
+		if [[ $__resp -ne 0 ]]; then
+			echo "ERROR: dep ${dep} not found:"
+			case "${dep}" in
+			"asdf")
+				echo -e "
+	Please ensure you have asdf installed on your system 
+	To install asdf, follow the instructions at https://asdf-vm.com/#/core-manage-asdf-vm 
+"
+			;;
+			esac
+			exit 1
+		fi
+	done
+
+	# Declaring local variables for the 'plugins' routine
+	local name
+	local url
+
+	# Declaring local variables for the 'versions' routine
+	local dir
+	local name
+	local version
+	local input=${1}
+
+	# Initialize array iterator
+	local i=0
+
+	# performing functionality for routine 'plugins'
+	for ((i=0; i<$( ysh -T "${input}" -c plugins ); i++)); do
+
+		# Getting fields for routine 'plugins'
+		name=$( ysh -T "${input}" -l plugins -i ${i} -Q name )
+		url=$( ysh -T "${input}" -l plugins -i ${i} -Q url )
+
+		# Writing message for routine 'plugins'
+		pretty_print ":info:" "🐙 adding ${name} plugin to asdf"
+
+		# Executing the command(s) for routine 'plugins'
+		run_command "asdf plugin-add ${name} ${url}"
+	done
+
+
+	# performing functionality for routine 'versions'
+	for ((i=0; i<$( ysh -T "${input}" -c versions ); i++)); do
+
+		# Getting fields for routine 'versions'
+		dir=$( ysh -T "${input}" -l versions -i ${i} -Q dir )
+		name=$( ysh -T "${input}" -l versions -i ${i} -Q name )
+		version=$( ysh -T "${input}" -l versions -i ${i} -Q version )
+
+		# Writing message for routine 'versions'
+		pretty_print ":info:" "⌨ shimming ${name} to ${version}"
+
+		# Executing the command(s) for routine 'versions'
+		run_command "test '${dir}' && (cd ${dir} && asdf local ${name} ${version}) || asdf global global ${name} ${version}"
+	done
+}

--- a/straps/asdf/v0.1.0/asdf.sh.DIGEST
+++ b/straps/asdf/v0.1.0/asdf.sh.DIGEST
@@ -1,0 +1,1 @@
+076b4d730b35b2bc758b28f2457f7d1df0d1075a3b505dbb295978e34defa8e6  straps/asdf/v0.1.0/asdf.sh


### PR DESCRIPTION
Added support for asdf version manager.

```yaml
strapped:
  repo: repo.strapped.sh

brew:
  packages:
    - { name: asdf }

asdf:
  plugins:
    - { name: clojure, url: https://github.com/halcyon/asdf-clojure.git }
    - { name: elixir,  url: https://github.com/asdf-vm/asdf-elixir.git }
  versions:
    - { name: clojure, version: 1.9.0 }
    - { name: elixir,  version: 1.8.2, dir: ~/projects/i-need-a-specific-version }
```