### PR TITLE
Track the deploy verb and gate on the pull request

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,24 @@
+name: Check
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# A superseded check has nothing to protect; cancel it. Deploys are the
+# opposite and say so in their own workflow.
+concurrency:
+  group: check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: jdx/mise-action@v4
+      - run: mise run check

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Never kill a deploy mid-flight; queued runs collapse to the tip.
+concurrency:
+  group: deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy to Cloudflare
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: jdx/mise-action@v4
+      # The verb is the release body. Never inline it here.
+      - run: mise run deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/mise.toml
+++ b/mise.toml
@@ -1,9 +1,5 @@
 # mise is the command surface for this repo: `mise tasks` lists the verbs.
 
-[tasks.setup]
-description = "Arm the commit gate"
-run = "mise generate git-pre-commit --write --task=pre-commit"
-
 [tasks.check]
 description = "Site integrity: every environment's index exists"
 run = """
@@ -15,11 +11,54 @@ done
 echo "check: all four sites intact"
 """
 
-[tasks.pre-commit]
-description = "Commit gate: branches author, main never does"
+[tools]
+node = "24"
+
+[tasks.deploy]
+description = "Deploy all four sites at merged main"
+confirm = "Deploy all four strapped.sh sites to production?"
+timeout = "10m"
+usage = 'flag "--dry-run" help="Validate without shipping"'
 run = """
 #!/usr/bin/env bash
 set -euo pipefail
-[ "$(git branch --show-current)" != "main" ] || { echo "pre-commit: refusing — commits are authored on branches, never on main" >&2; exit 1; }
+[ -n "${CLOUDFLARE_API_TOKEN:-}" ] || { echo "deploy: refusing — CLOUDFLARE_API_TOKEN is unset" >&2; exit 1; }
+[ "$(git rev-parse --git-dir)" = "$(git rev-parse --git-common-dir)" ] || { echo "deploy: refusing — deploy runs only from the main checkout" >&2; exit 1; }
+[ -z "$(git status --porcelain)" ] || { echo "deploy: refusing — tree is dirty" >&2; exit 1; }
+git fetch -q origin main
+# FETCH_HEAD, not origin/main: a CI checkout has no remote-tracking ref.
+[ "$(git rev-parse HEAD)" = "$(git rev-parse FETCH_HEAD)" ] || { echo "deploy: refusing — HEAD is not landed origin/main" >&2; exit 1; }
 mise run check
+# One worker per env, four hostnames off one source tree.
+envs="www repo stay docs"
+if [ "${usage_dry_run:-false}" = "true" ]; then
+  for e in $envs; do npx wrangler deploy --dry-run --env "$e"; done
+  echo "deploy: dry run complete — nothing shipped"
+  exit 0
+fi
+tag="$(git rev-parse --short HEAD)"
+message="$(git log -1 --pretty=%s)"
+for e in $envs; do
+  npx wrangler deploy --env "$e" --tag "$tag" --message "$message"
+done
+# Cloudflare is the authority on which version serves traffic. The public URL
+# cannot answer it: bot protection 403s a datacenter IP on some zones and not
+# others, so a status code there means nothing consistent.
+python3 - "$tag" $envs <<'VERIFY'
+import json, subprocess, sys
+
+def wrangler(*args):
+    r = subprocess.run(["npx", "wrangler", *args, "--json"], capture_output=True, text=True)
+    if r.returncode:
+        sys.exit(f"deploy: {' '.join(args)} failed — {r.stderr.strip()[:200]}")
+    return json.loads(r.stdout)
+
+want, envs = sys.argv[1], sys.argv[2:]
+for env in envs:
+    active = wrangler("deployments", "list", "--env", env)[-1]["versions"][0]["version_id"]
+    got = next((v["annotations"].get("workers/tag", "") for v in wrangler("versions", "list", "--env", env) if v["id"] == active), "")
+    if got != want:
+        sys.exit(f"deploy: refusing — {env} serving {active} carries tag {got!r}, expected {want!r}")
+    print(f"deploy: {env} live — {active} serving 100%, tagged {want}")
+VERIFY
 """


### PR DESCRIPTION
Move the deploy verb into mise.toml and authenticate from
CLOUDFLARE_API_TOKEN instead of a named wrangler profile, so the repo states
how it ships.

Remove the pre-commit and setup tasks. Add check.yml, which runs
`mise run check` on every pull request.

Deploy and verification both loop the four environments: each carries the
commit as its version tag, then Cloudflare is asked which version serves each.
The previous ending fetched four public URLs, whose statuses vary with each
zone's bot protection.